### PR TITLE
React navigation#22

### DIFF
--- a/src/Screens/Auth/auth.js
+++ b/src/Screens/Auth/auth.js
@@ -6,8 +6,12 @@ import {
 import LinearGradient from "react-native-linear-gradient"
 import TextInputMask from "react-native-text-input-mask"
 import firebase from "react-native-firebase"
+import { StackActions, NavigationActions } from "react-navigation"
 
 export default class Auth extends Component {
+  static navigationOptions = {
+  }
+
   constructor() {
     super()
     this.state = {
@@ -70,7 +74,18 @@ export default class Auth extends Component {
             keyboardType="number-pad"
           />
           <LinearGradient colors={["#547BF0", "#6AC3FB"]} style={styles.button}>
-            <Text style={styles.textButton} onPress={() => this.signIn()}>
+            <Text
+              style={styles.textButton}
+              onPress={() => {
+                this.signIn()
+                this.props.navigation.dispatch(StackActions.reset({
+                  index: 0,
+                  actions: [
+                    NavigationActions.navigate({ routeName: "VerificationScreen" })
+                  ],
+                }))
+              }}
+            >
               Verificar
             </Text>
           </LinearGradient>

--- a/src/Screens/Auth/auth.js
+++ b/src/Screens/Auth/auth.js
@@ -1,7 +1,11 @@
 import React, { Component } from "react"
 
 import {
-  View, Text, StyleSheet, Picker, Alert
+  View,
+  Text,
+  StyleSheet,
+  Picker,
+  Alert
 } from "react-native"
 import LinearGradient from "react-native-linear-gradient"
 import TextInputMask from "react-native-text-input-mask"
@@ -30,7 +34,14 @@ export default class Auth extends Component {
       .signInWithPhoneNumber(phoneNumber)
       .then(_confirmResult => {
         message = `Código de confirmação enviado para o número ${phoneNumber}`
-        // Encaminhar a variável message e o confirmResult como prop para o componente Verification
+
+        const { navigation } = this.props
+        navigation.dispatch(StackActions.reset({
+          index: 0,
+          actions: [
+            NavigationActions.navigate({ routeName: "VerificationScreen" })
+          ]
+        }))
       })
       .catch(error => {
         // eslint-disable-next-line max-len
@@ -76,15 +87,7 @@ export default class Auth extends Component {
           <LinearGradient colors={["#547BF0", "#6AC3FB"]} style={styles.button}>
             <Text
               style={styles.textButton}
-              onPress={() => {
-                this.signIn()
-                this.props.navigation.dispatch(StackActions.reset({
-                  index: 0,
-                  actions: [
-                    NavigationActions.navigate({ routeName: "VerificationScreen" })
-                  ],
-                }))
-              }}
+              onPress={() => this.signIn()}
             >
               Verificar
             </Text>

--- a/src/Screens/Auth/auth.js
+++ b/src/Screens/Auth/auth.js
@@ -10,7 +10,6 @@ import {
 import LinearGradient from "react-native-linear-gradient"
 import TextInputMask from "react-native-text-input-mask"
 import firebase from "react-native-firebase"
-import { StackActions, NavigationActions } from "react-navigation"
 
 export default class Auth extends Component {
   static navigationOptions = {
@@ -36,12 +35,9 @@ export default class Auth extends Component {
         message = `Código de confirmação enviado para o número ${phoneNumber}`
 
         const { navigation } = this.props
-        navigation.dispatch(StackActions.reset({
-          index: 0,
-          actions: [
-            NavigationActions.navigate({ routeName: "VerificationScreen" })
-          ]
-        }))
+        navigation.navigate("VerificationScreen", {
+          confirmResultFirebase: _confirmResult,
+        })
       })
       .catch(error => {
         // eslint-disable-next-line max-len

--- a/src/Screens/Auth/auth.js
+++ b/src/Screens/Auth/auth.js
@@ -10,6 +10,7 @@ import {
 import LinearGradient from "react-native-linear-gradient"
 import TextInputMask from "react-native-text-input-mask"
 import firebase from "react-native-firebase"
+import Conversas from "~/Screens/Conversas/conversas"
 
 export default class Auth extends Component {
   static navigationOptions = {
@@ -19,8 +20,20 @@ export default class Auth extends Component {
     super()
     this.state = {
       countryCode: "",
-      phoneNumber: null
+      phoneNumber: null,
+      loading: true,
+      authenticated: false,
     }
+  }
+
+  componentDidMount() {
+    firebase.auth().onAuthStateChanged(user => {
+      if (user) {
+        this.setState({ loading: false, authenticated: true })
+      } else {
+        this.setState({ loading: false, authenticated: false })
+      }
+    })
   }
 
   signIn = () => {
@@ -47,53 +60,57 @@ export default class Auth extends Component {
   }
 
   render() {
-    const { countryCode } = this.state
-    return (
-      <View style={styles.container}>
-        <View>
-          <Text style={styles.textBig}>Insira seu número de telefone</Text>
-        </View>
-        <View>
-          <Text style={styles.textSmall}>
-            Digite o número do seu telefone junto com o DDD
-          </Text>
-          <Picker
-            selectedValue={countryCode}
-            onValueChange={itemValue => this.setState({ countryCode: itemValue })
-            }
-          >
-            <Picker.Item label="Selecione um ID do País" value="" />
-            <Picker.Item label="+55 - Brasil" value="+55" />
-            <Picker.Item label="+1 - Country" value="+1" />
-          </Picker>
-        </View>
-        <View>
-          <TextInputMask
-            style={styles.textInputStyle}
-            placeholder={countryCode}
-            refInput={ref => {
-              this.input = ref
-            }}
-            onChangeText={extracted => {
-              this.setState({ phoneNumber: extracted })
-            }}
-            mask={`${countryCode} ([00]) [00000]-[0000]`}
-            keyboardType="number-pad"
-          />
-          <LinearGradient colors={["#547BF0", "#6AC3FB"]} style={styles.button}>
-            <Text
-              style={styles.textButton}
-              onPress={() => this.signIn()}
-            >
-              Enviar
+    const { countryCode, loading, authenticated } = this.state
+    if (loading) return null
+    if (!authenticated) {
+      return (
+        <View style={styles.container}>
+          <View>
+            <Text style={styles.textBig}>Insira seu número de telefone</Text>
+          </View>
+          <View>
+            <Text style={styles.textSmall}>
+              Digite o número do seu telefone junto com o DDD
             </Text>
-          </LinearGradient>
+            <Picker
+              selectedValue={countryCode}
+              onValueChange={itemValue => this.setState({ countryCode: itemValue })
+              }
+            >
+              <Picker.Item label="Selecione um ID do País" value="" />
+              <Picker.Item label="+55 - Brasil" value="+55" />
+              <Picker.Item label="+1 - Country" value="+1" />
+            </Picker>
+          </View>
+          <View>
+            <TextInputMask
+              style={styles.textInputStyle}
+              placeholder={countryCode}
+              refInput={ref => {
+                this.input = ref
+              }}
+              onChangeText={extracted => {
+                this.setState({ phoneNumber: extracted })
+              }}
+              mask={`${countryCode} ([00]) [00000]-[0000]`}
+              keyboardType="number-pad"
+            />
+            <LinearGradient colors={["#547BF0", "#6AC3FB"]} style={styles.button}>
+              <Text
+                style={styles.textButton}
+                onPress={() => this.signIn()}
+              >
+                Enviar
+              </Text>
+            </LinearGradient>
+          </View>
+          <Text style={styles.textEnd}>
+            Custos de SMS talvez possam ser aplicados
+          </Text>
         </View>
-        <Text style={styles.textEnd}>
-          Custos de SMS talvez possam ser aplicados
-        </Text>
-      </View>
-    )
+      )
+    }
+    return <Conversas />
   }
 }
 

--- a/src/Screens/Auth/auth.js
+++ b/src/Screens/Auth/auth.js
@@ -139,8 +139,8 @@ const styles = StyleSheet.create({
     color: "white"
   },
   button: {
-    width: 130,
-    height: 50,
+    width: 280,
+    height: 60,
     borderRadius: 20,
     alignSelf: "center",
     alignItems: "center",

--- a/src/Screens/Auth/auth.js
+++ b/src/Screens/Auth/auth.js
@@ -89,7 +89,7 @@ export default class Auth extends Component {
               style={styles.textButton}
               onPress={() => this.signIn()}
             >
-              Verificar
+              Enviar
             </Text>
           </LinearGradient>
         </View>

--- a/src/Screens/Verification/verification.js
+++ b/src/Screens/Verification/verification.js
@@ -9,7 +9,6 @@ import {
 } from "react-native"
 import LinearGradient from "react-native-linear-gradient"
 import CodeInput from "react-native-confirmation-code-input"
-import { StackActions, NavigationActions } from "react-navigation"
 
 const styles = StyleSheet.create({
   principal: {
@@ -63,13 +62,16 @@ export default class Verificacao extends Component {
   }
 
   confirmChoice = code => {
-    const { confirmResult } = this.props
+    const { navigation } = this.props
+    const confirmResult = navigation.getParam("confirmResultFirebase")
 
     if (confirmResult && code.length) {
       confirmResult
         .confirm(code)
         // Continuar as rotas se a confirmação ocorrer com sucesso aqui
-        .then(() => {})
+        .then(() => {
+          navigation.navigate("ConversationScreen")
+        })
         // Caso dê algum erro, o tratamento é feito aqui
         .catch(() => {})
     }
@@ -83,10 +85,10 @@ export default class Verificacao extends Component {
         </View>
         <View style={styles.code}>
           <CodeInput
-            codeLength={4}
+            codeLength={6}
             className="border-b"
             space={20}
-            size={50}
+            size={40}
             inactiveColor="gray"
             activeColor="gray"
             inputPosition="left"

--- a/src/Screens/Verification/verification.js
+++ b/src/Screens/Verification/verification.js
@@ -1,9 +1,15 @@
 /* eslint-disable object-curly-newline */
 import React, { Component } from "react"
 
-import { View, Text, StyleSheet, Linking } from "react-native"
+import {
+  View,
+  Text,
+  StyleSheet,
+  Linking
+} from "react-native"
 import LinearGradient from "react-native-linear-gradient"
 import CodeInput from "react-native-confirmation-code-input"
+import { StackActions, NavigationActions } from "react-navigation"
 
 const styles = StyleSheet.create({
   principal: {

--- a/src/Screens/Verification/verification.js
+++ b/src/Screens/Verification/verification.js
@@ -92,6 +92,7 @@ export default class Verificacao extends Component {
             inactiveColor="gray"
             activeColor="gray"
             inputPosition="left"
+            keyboardType="number-pad"
             onFulfill={code => this.confirmChoice(code)}
           />
         </View>

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,7 +11,7 @@ const appStackNavigator = createStackNavigator({
   VerificationScreen: {
     screen: Verification
   },
-  ChatScreen: {
+  ConversationScreen: {
     screen: Conversas
   }
 }, {

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,8 +1,23 @@
-import { createAppContainer, createSwitchNavigator } from "react-navigation"
+import { createAppContainer, createStackNavigator } from "react-navigation"
 
-// import Conversas from "~/Screens/Conversas/conversas"
 import Auth from "~/Screens/Auth/auth"
+import Verification from "~/Screens/Verification/verification"
+import Conversas from "~/Screens/Conversas/conversas"
 
-const Routes = createAppContainer(createSwitchNavigator({ Auth }))
+const appStackNavigator = createStackNavigator({
+  AuthScreen: {
+    screen: Auth
+  },
+  VerificationScreen: {
+    screen: Verification
+  },
+  ChatScreen: {
+    screen: Conversas
+  }
+}, {
+  initialRouteName: "AuthScreen"
+})
+
+const Routes = createAppContainer(appStackNavigator)
 
 export default Routes


### PR DESCRIPTION
Configurado o routes.js para "abrigar" todas as telas criadas e que seriam necessárias para o acesso inicial do Unichat.
Criado o processo de navegar entre as telas AuthScreen -> VerificationScreen -> ConversationScreen

- AuthScreen:
Só vai para a próxima tela após a confirmação do firebase, caso contrário, aparecera uma mensagem de erro referente ao erro ocorrido. Adicionado também uma função que verifica se o usuário já está logado naquele dispositivo, caso esteja, então ele vai direto para a ConversationScreen. Alterado também o Label do botão de _Verificar_ para _Enviar_.

- VerificationScreen:
Alterado o input do textCode para 6 (anteriormente era 4) para se adequar ao tamanho do código recebido pelo firebase. Adicionado o método para navegar até a ConversationScreen caso o código esteja correto e o retorno do firebase seja True também.

- ConversationScreen:
Nada alterado nesta tela.